### PR TITLE
Fixing and expanding watch mode

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -97,7 +97,7 @@ compile(args);
 // Watch for changes with flag --watch
 if (args.watch) {
   watch(
-    './src/html/',
+    args.src,
     {
       recursive: true,
       filter: /\.html$/

--- a/bin/compile.js
+++ b/bin/compile.js
@@ -4,7 +4,7 @@ const watch = require('node-watch'),
   glob = require('glob');
 
 const options = [
-  { name: 'watch', alias: 'w', type: Boolean },
+  { name: 'watch', alias: 'w', type: String, multiple: true},
   { name: 'src', alias: 's', type: String },
   { name: 'dest', alias: 'd', type: String }
 ];
@@ -95,9 +95,10 @@ const compile = args => {
 compile(args);
 
 // Watch for changes with flag --watch
-if (args.watch) {
+if (typeof(args.watch) != 'undefined') {
+  if(args.watch == null || !args.watch.length) args.watch = args.src;
   watch(
-    args.src,
+    args.watch,
     {
       recursive: true,
       filter: /\.html$/


### PR DESCRIPTION
I noticed the watch mode had a hard-coded path. I fixed that and added support for passing one or multiple folders to be watched (not necessarily the src folder). 