### PR TITLE
Fix whatever was causing "," to be in the evaluation path.

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -91,8 +91,7 @@ const compile = args => {
 
         let root = path.split("/");
         root.pop();
-        root.join("/");
-        root += "/";
+        root = root.join("/") + "/";
 
         let filePath = root + data[match];
         // console.log(filePath);


### PR DESCRIPTION
Basically the include path was evaluating to `,src,htm,` instead of `/src/html` this seemed to fix it, not sure if it is some sort of race condition etc... Didn't have time to figure it out.