### PR TITLE
Added '--quiet' option to silence successful saves.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Or with the `--minify` flag, you'd get:
 | `--watch`                   | Watch for file changes                                                                                                                               | false                  |
 | `--minify`                  | Enable Minification of HTML                                                                                                                          | false                  |
 | `--minify option=[boolean]` | Set any of the boolean options in https://github.com/kangax/html-minifier#options-quick-reference - for example `--minify conservativeCollapse=true` | Various typical values |
+| `--quiet`                   | Silence successful save logs                                                                                                                         | false                  |
 
 ### Notes
 

--- a/bin/compile.js
+++ b/bin/compile.js
@@ -19,6 +19,7 @@ const options = [
   { name: "src", alias: "s", type: String, defaultValue: "src" },
   { name: "dest", alias: "d", type: String, defaultValue: "dist" },
   { name: "minify", alias: "m", type: String, multiple: true },
+  { name: "quiet", alias: "q", type: String, defaultValue: false }
 ];
 const args = commandLineArgs(options);
 
@@ -209,7 +210,9 @@ const compile = (args) => {
         // Save the file to dist
         let filename = file.path.substring(args.src.length);
         let outputFilePath = args.dest + filename;
-        console.log("Saving: " + file.path + "-> " + outputFilePath);
+        if (args.quiet === false) {
+          console.log("Saving: " + file.path + "-> " + outputFilePath);
+        }
 
         file.content = minimizeOptions
           ? htmlMinifier.minify(file.content, minimizeOptions)


### PR DESCRIPTION
I think this is a nice option when using this package in longer build scripts. 
Only removes success logs. Leaves error logging.